### PR TITLE
Security: fix XSS on upload response (NGP-610)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -10,9 +10,9 @@ app.use(express.static('public'));
 
 app.post('/upload', upload.single('pdf'), (req, res) => {
   if (!req.file) {
-    return res.status(400).send('No file uploaded.');
+    return res.status(400).type('text/plain').send('No file uploaded.');
   }
-  res.send(`File uploaded: ${req.file.filename}`);
+  res.type('text/plain').send(`File uploaded: ${req.file.filename}`);
 });
 
 app.get('/download/:filename', (req, res) => {


### PR DESCRIPTION
## Summary
Fixes **Cross-site Scripting (CWE-79)** on `/upload` by sending confirmation and error responses with `Content-Type: text/plain` so reflected multer file metadata is not interpreted as HTML.

## Jira
- [NGP-610](https://jack683ryan.atlassian.net/browse/NGP-610)

## Changes
- `index.ts`: `res.type('text/plain')` before `send()` for upload success and `400` responses.

## Validation
- Snyk Code (high+): XSS issue resolved (re-scan clean at high threshold)
- `npm run build` (tsc): pass

## Note
`npm test` may fail locally without a Jest + TypeScript preset; not introduced by this change.

Made with [Cursor](https://cursor.com)

[NGP-610]: https://jack683ryan.atlassian.net/browse/NGP-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ