### PR TITLE
Security: Fix XSS on upload response (NGP-610)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -12,7 +12,7 @@ app.post('/upload', upload.single('pdf'), (req, res) => {
   if (!req.file) {
     return res.status(400).send('No file uploaded.');
   }
-  res.send(`File uploaded: ${req.file.filename}`);
+  res.type('text/plain').send(`File uploaded: ${req.file.filename}`);
 });
 
 app.get('/download/:filename', (req, res) => {


### PR DESCRIPTION
## Summary
Remediates **Cross-site Scripting (CWE-79)** reported by Snyk: unsanitized uploaded file name was reflected in `res.send`, which defaults to HTML-capable responses.

## Change
- Set `Content-Type: text/plain` for the upload confirmation via `res.type('text/plain').send(...)` so the filename is not interpreted as HTML.

## Jira
- [NGP-610](https://jack683ryan.atlassian.net/browse/NGP-610)

## Validation
- Snyk Code: XSS issue resolved; remaining medium issues (X-Powered-By, rate limiting on download) unchanged and out of scope for this ticket.

## Checklist
- [x] Targeted fix only (no batch / unrelated issues)
- [x] Snyk re-scan confirms XSS cleared


Made with [Cursor](https://cursor.com)

[NGP-610]: https://jack683ryan.atlassian.net/browse/NGP-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ