### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "Snyk": {
+      "command": "snyk",
+      "args": ["mcp", "-t", "stdio"],
+      "env": {}
+    }
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a single small product: `foo-bar-app`, an Express + TypeScript web app for uploading PDFs and downloading them later. Uploaded files are stored on the local filesystem under `uploads/` (created at runtime) — there is no database or external service.
+
+### Build / run (non-obvious gotchas)
+- The build output path is **not** `dist/`. `tsconfig.json` sets `outDir: "."`, so `npm run build` (`tsc`) compiles `index.ts` into `index.js` in the repo root.
+- The `start` script in `package.json` (`node dist/server.js`) and `main` (`dist/index.js`) are **stale/incorrect** — `dist/server.js` does not exist. Run the app the way the README documents instead: `npm run build` then `node index.js`. It listens on http://localhost:3000 (port is hardcoded).
+- After editing `index.ts`, you must re-run `npm run build` (`tsc`) before `node index.js` picks up changes; there is no watch/hot-reload script.
+
+### Test
+- `npm test` runs Jest (via `ts-jest`). A `posttest` step deletes the `uploads/` directory.
+- The fixture `tests/test.pdf` is an empty (0-byte) file, so a curl upload/download round-trip with it trivially "matches". For meaningful manual verification, upload a real non-empty PDF.
+
+### Lint
+- No linter is configured (no ESLint/Prettier, no `lint` script).
+
+### Note
+- The app intentionally contains a path-traversal vulnerability in `GET /download/:filename` (it's a Snyk demo app). Do not treat that as a bug to fix unless asked.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,3 +18,8 @@ This repo is a single small product: `foo-bar-app`, an Express + TypeScript web 
 
 ### Note
 - The app intentionally contains a path-traversal vulnerability in `GET /download/:filename` (it's a Snyk demo app). Do not treat that as a bug to fix unless asked.
+
+### Snyk MCP server
+- The Snyk MCP server is configured in `.cursor/mcp.json` (`snyk mcp -t stdio`). Cursor reads this file at startup, so adding/changing it requires reloading Cursor before the `Snyk` server and its tools (`snyk_code_scan`, `snyk_sca_scan`, `snyk_auth`, etc.) appear.
+- It relies on the Snyk CLI being on `PATH`. The startup script installs it to `/usr/local/bin/snyk`. The usual `npx -y snyk@latest mcp -t stdio` does NOT work here: the `snyk` npm wrapper downloads its binary from `static.snyk.io`, which is blocked by this environment's network egress. The binary is instead fetched from GitHub release assets (`github.com/snyk/cli/releases`, which is reachable).
+- The MCP server boots and lists tools without authentication, but actually running scans needs both a Snyk token (e.g. `SNYK_TOKEN`) and network access to Snyk hosts. `api.snyk.io` / `static.snyk.io` are currently blocked by network egress, so live scans fail with `SNYK-CLI-0022` network errors until those hosts are allowlisted in the cloud agent Network Access settings.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up and verifies the development environment for the `foo-bar-app` Express + TypeScript PDF upload/download app, documents non-obvious setup caveats for future cloud agents, and adds the Snyk MCP server to the environment.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing durable gotchas (stale `start`/`main` paths pointing at non-existent `dist/server.js`, `tsc` outputs `index.js` to repo root, empty `tests/test.pdf` fixture, no lint configured, intentional path-traversal demo vuln, Snyk MCP notes).
- Adds `.cursor/mcp.json` configuring the **Snyk MCP server** (`snyk mcp -t stdio`).
- Update script set to `npm install` plus a guarded, non-fatal install of the Snyk CLI to `/usr/local/bin/snyk` from GitHub release assets (Snyk's own CDN is blocked by network egress here).

## Verification
- `npm install` / `npm run build` (`tsc`) / `npm test` (3/3 Jest pass) / `node index.js` (http://localhost:3000).
- End-to-end: uploaded a real PDF via the browser UI and downloaded it back; PDF rendered correctly.
- Snyk MCP server boots via `snyk mcp -t stdio` and exposes its tools (`snyk_code_scan`, `snyk_sca_scan`, `snyk_auth`, etc.) — verified with an MCP `initialize` + `tools/list` handshake.

### Notes / limitations
- The `Snyk` server only appears in Cursor after a reload (Cursor reads `.cursor/mcp.json` at startup).
- Running live Snyk scans requires a Snyk token AND network access to `api.snyk.io` / `static.snyk.io`, which are currently blocked by network egress (`SNYK-CLI-0022`). Allowlist those hosts in Network Access settings and add a `SNYK_TOKEN` to run scans.

[pdf_upload_download_demo.mp4](https://cursor.com/agents/bc-16883576-ec7e-448d-92ce-6018ce8cd8ed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpdf_upload_download_demo.mp4)

[Upload confirmation](https://cursor.com/agents/bc-16883576-ec7e-448d-92ce-6018ce8cd8ed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fupload_confirmation.webp)
[Downloaded PDF rendered](https://cursor.com/agents/bc-16883576-ec7e-448d-92ce-6018ce8cd8ed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpdf_downloaded.webp)

Snyk MCP server handshake:
[snyk_mcp_handshake.log](https://cursor.com/agents/bc-16883576-ec7e-448d-92ce-6018ce8cd8ed/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsnyk_mcp_handshake.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-16883576-ec7e-448d-92ce-6018ce8cd8ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-16883576-ec7e-448d-92ce-6018ce8cd8ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

