### PR TITLE
Set up development environment and add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a small single-service **Node.js + TypeScript (Express)** demo app: a PDF
+upload/download web app used for Snyk security demos. There is no database, cache, queue,
+or other external service — running it end-to-end requires only the one Node process.
+
+Standard commands live in `package.json` and `README.md`. Key notes:
+
+- **Build/run:** `npm run build` (runs `tsc`, emitting `index.js` in the repo root per
+  `tsconfig.json` `outDir: "."`), then `node index.js`. The server listens on hardcoded
+  port **3000** (`http://localhost:3000`).
+- **`npm start` is broken — do not use it.** It points at `node dist/server.js`, but no
+  `server.ts`/`server.js` exists and `tsc` outputs to the repo root, not `dist/`. Run the
+  app with `node index.js` instead (as documented in `README.md`).
+- **Tests:** `npm test` (Jest + ts-jest + Supertest, config inline in `package.json`).
+  The `posttest` hook deletes the `uploads/` dir; the test fixtures `tests/test.pdf` and
+  `tests/test.jpg` are intentionally 0-byte files.
+- **No linter is configured** (no ESLint/Prettier/tslint). There is no lint command.
+- The frontend (`public/index.html`) calls `GET /download` to list files, but the backend
+  only implements `GET /download/:filename` — so the file list stays empty. This is a
+  known cosmetic mismatch and does not affect the upload/download flow.
+- This app intentionally contains a Path Traversal vulnerability in `/download/:filename`
+  (for the Snyk demo). Do not "fix" it unless explicitly asked.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for this Node.js + TypeScript (Express) PDF upload/download demo app and verifies it end-to-end. Adds `AGENTS.md` with durable, Cursor Cloud specific instructions for future agents.

The only code change is the new `AGENTS.md`. No application source was modified.

## Environment setup

- **Update script:** `npm install` (idempotent dependency refresh)
- Node `v22.14.0`, npm `10.9.7`

## Verification

- ✅ `npm install` — installed 395 packages
- ✅ `npm run build` (`tsc`) — emits `index.js` in repo root
- ✅ `npm test` — 3/3 Jest tests pass (upload, invalid-type rejection, 404)
- ✅ `node index.js` — server runs on port 3000
- ✅ End-to-end: uploaded a PDF and downloaded it back (byte-identical), via API and the browser UI

### Walkthrough

[pdf_upload_demo.mp4](https://cursor.com/agents/bc-3e11f80e-9201-4769-bf2f-83773aced116/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpdf_upload_demo.mp4)

Browser upload of a PDF returning a `File uploaded: <id>` success response.

[Upload success page](https://cursor.com/agents/bc-3e11f80e-9201-4769-bf2f-83773aced116/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fupload_success.webp)

## Notes captured in AGENTS.md

- `npm start` is broken (references non-existent `dist/server.js`); run with `node index.js` after `npm run build`.
- No linter is configured.
- Frontend calls `GET /download` (unimplemented list endpoint); only `GET /download/:filename` exists — cosmetic mismatch.
- App intentionally contains a Path Traversal vulnerability for the Snyk demo.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e11f80e-9201-4769-bf2f-83773aced116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e11f80e-9201-4769-bf2f-83773aced116"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

